### PR TITLE
support nested flags parse/setup

### DIFF
--- a/fftoml/fftoml.go
+++ b/fftoml/fftoml.go
@@ -19,37 +19,38 @@ func Parser(r io.Reader, set func(name, value string) error) error {
 		return ParseError{Inner: err}
 	}
 	for key, val := range m {
-		values, err := valsToStrs(val)
+		err := setup(key, val, set)
 		if err != nil {
-			return ParseError{Inner: err}
-		}
-		for _, value := range values {
-			if err = set(key, value); err != nil {
-				return err
-			}
+			return ParseError{err}
 		}
 	}
 	return nil
 }
 
-func valsToStrs(val interface{}) ([]string, error) {
-	if vals, ok := val.([]interface{}); ok {
-		ss := make([]string, len(vals))
-		for i := range vals {
-			s, err := valToStr(vals[i])
+func setup(key string, val interface{}, set func(name, value string) error) error {
+	if obj, ok := val.(map[string]interface{}); ok {
+		for sub, val := range obj {
+			err := setup(join(key, sub), val, set)
 			if err != nil {
-				return nil, err
+				return err
 			}
-			ss[i] = s
 		}
-		return ss, nil
+		return nil
+	}
+	if vals, ok := val.([]interface{}); ok {
+		for _, val := range vals {
+			err := setup(key, val, set)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 	s, err := valToStr(val)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return []string{s}, nil
-
+	return set(key, s)
 }
 
 func valToStr(val interface{}) (string, error) {
@@ -83,4 +84,8 @@ func (e ParseError) Error() string {
 // xerrors.Is and xerrors.As to work with ParseErrors.
 func (e ParseError) Unwrap() error {
 	return e.Inner
+}
+
+func join(a, b string) string {
+	return a + "." + b
 }

--- a/fftoml/fftoml_test.go
+++ b/fftoml/fftoml_test.go
@@ -1,6 +1,7 @@
 package fftoml_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -33,6 +34,14 @@ func TestParser(t *testing.T) {
 			want: fftest.Vars{S: "s", I: 10, F: 3.14e10, B: true, D: 5 * time.Second, X: []string{"1", "a", "👍"}},
 		},
 		{
+			name: "sub value",
+			file: `
+			[sub]
+			s = "hello"
+			`,
+			want: fftest.Vars{SubS: "hello"},
+		},
+		{
 			name: "bad TOML file",
 			file: `{`,
 			want: fftest.Vars{WantParseErrorString: "bare keys cannot contain '{'"},
@@ -47,6 +56,7 @@ func TestParser(t *testing.T) {
 				ff.WithConfigFile(filename),
 				ff.WithConfigFileParser(fftoml.Parser),
 			)
+			fmt.Println(vars)
 
 			if err := fftest.Compare(&testcase.want, vars); err != nil {
 				t.Fatal(err)

--- a/ffyaml/ffyaml_test.go
+++ b/ffyaml/ffyaml_test.go
@@ -60,6 +60,11 @@ func TestParser(t *testing.T) {
 			file: "x: [one, two, three]",
 			want: fftest.Vars{X: []string{"one", "two", "three"}},
 		},
+		{
+			name: "sub string",
+			file: "sub.s: hello",
+			want: fftest.Vars{SubS: "hello"},
+		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
 			filename, cleanup := fftest.TempFile(t, testcase.file)


### PR DESCRIPTION
Hi! First of all, thank you for such good interpretation of how Go programs should be configured.

This PR brings an ability to export flags by some libraries/components of the program which support some conventions of exporting their parameters:

```go
package main

import (
    "github.com/peterbourgon/ff"

    "my/cool/lib/libconfig"
)

func main() {
    fs := flag.NewFlagSet("main", 0)
    ...
    ff.Subset(fs, "lib", func(fs *flag.FlagSet) {
        _ = libconfig.Export(fs)
    })
    ff.Parse(fs, ...)
}
```

```go
package libconfig

import "my/cool/lib"

type Config interface {
    StringVar(p *string, name, value, usage string)
}

func Export(c Config) (ret *lib.Config) {
    ret = new(lib.Config)
    c.StringVar(&ret.Foo, "foo", "bar", "usage")
    return
}
```

This will allow to run our program as `binary -lib.foo xxx` and so on.