### PR TITLE
ffcli: UsageFunc, flag.ErrHelp

### DIFF
--- a/ffcli/command.go
+++ b/ffcli/command.go
@@ -1,6 +1,7 @@
 package ffcli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"strings"
@@ -93,7 +94,7 @@ func (c *Command) Run(args []string) error {
 
 	if c.Exec != nil {
 		err := c.Exec(c.FlagSet.Args())
-		if err == flag.ErrHelp {
+		if errors.Is(err, flag.ErrHelp) {
 			c.FlagSet.Usage()
 		}
 		return err

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/peterbourgon/ff
 
+go 1.13
+
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/mitchellh/go-wordwrap v1.0.0

--- a/parse.go
+++ b/parse.go
@@ -19,7 +19,7 @@ func Parse(fs *flag.FlagSet, args []string, options ...Option) error {
 	}
 
 	if err := fs.Parse(args); err != nil {
-		return fmt.Errorf("error parsing commandline args: %v", err)
+		return fmt.Errorf("error parsing commandline args: %w", err)
 	}
 
 	provided := map[string]bool{}


### PR DESCRIPTION
ffcli.Command now has a UsageFunc, which allows users to customize the usage text displayed when -h is provided. Also, if Exec returns flag.ErrHelp, that usage text is displayed.

Cherry-picked from long-running ffcli-enhancements branch, [see this comment](https://github.com/peterbourgon/ff/pull/38#issuecomment-531885640).