### PR TITLE
Add IgnoreUndefined option

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -41,7 +41,7 @@ func Parse(fs *flag.FlagSet, args []string, options ...Option) error {
 		defer f.Close()
 
 		err = c.configFileParser(f, func(name, value string) error {
-			if fs.Lookup(name) == nil {
+			if fs.Lookup(name) == nil && !c.ignoreUndefined {
 				return fmt.Errorf("config file flag %q not defined in flag set", name)
 			}
 
@@ -109,6 +109,7 @@ type Context struct {
 	envVarPrefix       string
 	envVarNoPrefix     bool
 	envVarIgnoreCommas bool
+	ignoreUndefined    bool
 }
 
 // Option controls some aspect of parse behavior.
@@ -165,6 +166,14 @@ func WithEnvVarNoPrefix() Option {
 func WithEnvVarIgnoreCommas(ignore bool) Option {
 	return func(c *Context) {
 		c.envVarIgnoreCommas = ignore
+	}
+}
+
+// WithIgnoreUndefined tells parse to ignore undefined flags that it encounters,
+// which would normally throw an error.
+func WithIgnoreUndefined(ignore bool) Option {
+	return func(c *Context) {
+		c.ignoreUndefined = ignore
 	}
 }
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -97,6 +97,12 @@ func TestParseBasics(t *testing.T) {
 			want: fftest.Vars{S: "one,two,three", X: []string{"one,two,three"}},
 		},
 		{
+			name: "WithIgnoreUndefined",
+			env:  map[string]string{"TEST_PARSE_UNDEFINED": "one", "TEST_PARSE_S": "one"},
+			opts: []ff.Option{ff.WithIgnoreUndefined(true)},
+			want: fftest.Vars{S: "one"},
+		},
+		{
 			name: "env var comma whitespace",
 			env:  map[string]string{"TEST_PARSE_S": "one, two, three ", "TEST_PARSE_X": "one, two, three "},
 			want: fftest.Vars{S: " three ", X: []string{"one", " two", " three "}},


### PR DESCRIPTION
I think it might be useful for some people (like me) to have an option to ignore undefined keys. The best use case for this imo is when sharing a config over multiple binaries.