### PR TITLE
Add support for TOML tables to fftoml package

### DIFF
--- a/fftoml/fftoml_test.go
+++ b/fftoml/fftoml_test.go
@@ -82,7 +82,7 @@ func TestParser_WithTables(t *testing.T) {
 		},
 		{
 			name:       "defaults",
-			opts:       []fftoml.Option{fftoml.FlagSeparator("-")},
+			opts:       []fftoml.Option{fftoml.TableDelimeter("-")},
 			stringKey:  "string-key",
 			floatKey:   "float-nested-key",
 			stringsKey: "strings-nested-key",
@@ -100,7 +100,7 @@ func TestParser_WithTables(t *testing.T) {
 
 			if err := ff.Parse(fs, []string{},
 				ff.WithConfigFile("testdata/table.toml"),
-				ff.WithConfigFileParser(fftoml.ParserWith(testcase.opts...))); err != nil {
+				ff.WithConfigFileParser(fftoml.New(testcase.opts...).Parse)); err != nil {
 				t.Fatal(err)
 			}
 

--- a/fftoml/fftoml_test.go
+++ b/fftoml/fftoml_test.go
@@ -1,6 +1,8 @@
 package fftoml_test
 
 import (
+	"flag"
+	"reflect"
 	"testing"
 	"time"
 
@@ -23,12 +25,19 @@ func TestParser(t *testing.T) {
 		{
 			name: "basic KV pairs",
 			file: "testdata/basic.toml",
-			want: fftest.Vars{S: "s", I: 10, F: 3.14e10, B: true, D: 5 * time.Second, X: []string{"1", "a", "👍"}},
+			want: fftest.Vars{
+				S: "s",
+				I: 10,
+				F: 3.14e10,
+				B: true,
+				D: 5 * time.Second,
+				X: []string{"1", "a", "👍"},
+			},
 		},
 		{
 			name: "bad TOML file",
 			file: "testdata/bad.toml",
-			want: fftest.Vars{WantParseErrorString: "bare keys cannot contain '{'"},
+			want: fftest.Vars{WantParseErrorString: "keys cannot contain { character"},
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {
@@ -41,5 +50,39 @@ func TestParser(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestParser_WithTables(t *testing.T) {
+	var (
+		tc struct {
+			String  string
+			Float   float64
+			Strings fftest.StringSlice
+		}
+		fs = flag.NewFlagSet("fftest", flag.ContinueOnError)
+	)
+
+	fs.StringVar(&tc.String, "string-key", "", "string")
+	fs.Float64Var(&tc.Float, "float-nested-key", 0, "float64")
+	fs.Var(&tc.Strings, "strings-nested-key", "string slice")
+
+	if err := ff.Parse(fs, []string{},
+		ff.WithConfigFile("testdata/table.toml"),
+		ff.WithConfigFileParser(fftoml.Parser)); err != nil {
+		t.Fatal(err)
+	}
+
+	if tc.String != "a string" {
+		t.Errorf(`expected string to be "a string", found %q`, tc.String)
+	}
+
+	if tc.Float != 1.23 {
+		t.Errorf("expected float to be 1.23, found %v", tc.Float)
+	}
+
+	expected := fftest.StringSlice{"one", "two", "three"}
+	if !reflect.DeepEqual(tc.Strings, expected) {
+		t.Errorf("expected strings to be %q, found %q", expected, tc.Strings)
 	}
 }

--- a/fftoml/fftoml_test.go
+++ b/fftoml/fftoml_test.go
@@ -82,7 +82,7 @@ func TestParser_WithTables(t *testing.T) {
 		},
 		{
 			name:       "defaults",
-			opts:       []fftoml.Option{fftoml.TableDelimeter("-")},
+			opts:       []fftoml.Option{fftoml.WithTableDelimiter("-")},
 			stringKey:  "string-key",
 			floatKey:   "float-nested-key",
 			stringsKey: "strings-nested-key",

--- a/fftoml/testdata/table.toml
+++ b/fftoml/testdata/table.toml
@@ -1,0 +1,7 @@
+[string]
+key = "a string"
+[float]
+[float.nested]
+key = 1.23
+[strings.nested]
+key = ["one", "two", "three"]

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/peterbourgon/ff
 go 1.13
 
 require (
-	github.com/BurntSushi/toml v0.3.1
 	github.com/mitchellh/go-wordwrap v1.0.0
+	github.com/pelletier/go-toml v1.6.0
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,14 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
+github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This adds support for TOML tables. It does so by concatenating nested keys with the `-` character.

For example:

```toml
[a]
b = "c"
```
Will set the flag `-a-b` with the value `"c"`.

```go
var b string
flagset.StringVar(&b, "a-b", "a string")
// ...
```

This swaps to a different toml parser (namely `github.com/pelletier/go-toml`), however, upon reflection the BurntSushi version is probably still useable. I can swap to attempt that if that would be more preferrable.

