### PR TITLE
Expand WithConfigFile/WithConfigFileFlag docs

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -132,12 +132,8 @@ type Option func(*Context)
 
 // WithConfigFile tells Parse to read the provided filename as a config file.
 // Requires WithConfigFileParser, and overrides WithConfigFileFlag.
-//
-// If you want both a config file flag and a default value when one is
-// unprovided, use WithConfigFileFlag and set your chosen default when
-// defining the flag. Because config files should generally be
-// user-specifiable, this option should be rarely used. Prefer
-// WithConfigFileFlag.
+// Because config files should generally be user-specifiable, this option
+// should be rarely used. Prefer WithConfigFileFlag.
 func WithConfigFile(filename string) Option {
 	return func(c *Context) {
 		c.configFile = filename

--- a/parse.go
+++ b/parse.go
@@ -131,10 +131,13 @@ type Context struct {
 type Option func(*Context)
 
 // WithConfigFile tells Parse to read the provided filename as a config file.
-// Requires WithConfigFileParser, and overrides WithConfigFileFlag. If you
-// want both a config file flag and a default value when one is unprovided,
-// use WithConfigFileFlag and set your chosen default when defining the
-// flag.
+// Requires WithConfigFileParser, and overrides WithConfigFileFlag.
+//
+// If you want both a config file flag and a default value when one is
+// unprovided, use WithConfigFileFlag and set your chosen default when
+// defining the flag. Because config files should generally be
+// user-specifiable, this option should be rarely used. Prefer
+// WithConfigFileFlag.
 func WithConfigFile(filename string) Option {
 	return func(c *Context) {
 		c.configFile = filename
@@ -142,9 +145,12 @@ func WithConfigFile(filename string) Option {
 }
 
 // WithConfigFileFlag tells Parse to treat the flag with the given name as a
-// config file. The caller will still need to define the flag in a FlagSet
-// (and can provide a default via that definition). Requires
-// WithConfigFileParser, and is overridden by WithConfigFile.
+// config file. Requires WithConfigFileParser, and is overridden by
+// WithConfigFile.
+//
+// To specify a default config file, provide it as the default value of the
+// corresponding flag -- and consider also using the WithAllowMissingConfigFile
+// option.
 func WithConfigFileFlag(flagname string) Option {
 	return func(c *Context) {
 		c.configFileFlagName = flagname

--- a/parse.go
+++ b/parse.go
@@ -131,7 +131,10 @@ type Context struct {
 type Option func(*Context)
 
 // WithConfigFile tells Parse to read the provided filename as a config file.
-// Requires WithConfigFileParser, and overrides WithConfigFileFlag.
+// Requires WithConfigFileParser, and overrides WithConfigFileFlag. If you
+// want both a config file flag and a default value when one is unprovided,
+// use WithConfigFileFlag and set your chosen default when defining the
+// flag.
 func WithConfigFile(filename string) Option {
 	return func(c *Context) {
 		c.configFile = filename
@@ -139,8 +142,9 @@ func WithConfigFile(filename string) Option {
 }
 
 // WithConfigFileFlag tells Parse to treat the flag with the given name as a
-// config file. Requires WithConfigFileParser, and is overridden by
-// WithConfigFile.
+// config file. The caller will still need to define the flag in a FlagSet
+// (and can provide a default via that definition). Requires
+// WithConfigFileParser, and is overridden by WithConfigFile.
 func WithConfigFileFlag(flagname string) Option {
 	return func(c *Context) {
 		c.configFileFlagName = flagname


### PR DESCRIPTION
Originally I wrote https://github.com/peterbourgon/ff/pull/60, but then after adding that patch and trying to use it, I figured out https://github.com/peterbourgon/ff/pull/60 was wrong and I just didn't know how to use the existing code. This PR adds the documentation I could have used to avoid thinking I needed https://github.com/peterbourgon/ff/pull/60.