### PR TITLE
WIP: Define FlagSet interface

### DIFF
--- a/fftest/vars.go
+++ b/fftest/vars.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/spf13/pflag"
 )
 
 // Pair returns a predefined flag set, and a predefined set of variables that
@@ -25,6 +27,16 @@ func Pair() (*flag.FlagSet, *Vars) {
 	fs.Var(&v.X, "x", "collection of strings (repeatable)")
 
 	return fs, &v
+}
+
+// PairPflag returns the same flagset as Pair but uses pflag.
+func PairPflag() (*pflag.FlagSet, *Vars) {
+	fs, v := Pair()
+
+	pfs := pflag.NewFlagSet("fftest", pflag.ContinueOnError)
+	pfs.AddGoFlagSet(fs)
+
+	return pfs, v
 }
 
 // Vars are a common set of variables used for testing.

--- a/fftoml/fftoml_test.go
+++ b/fftoml/fftoml_test.go
@@ -51,6 +51,15 @@ func TestParser(t *testing.T) {
 			if err := fftest.Compare(&testcase.want, vars); err != nil {
 				t.Fatal(err)
 			}
+
+			pfs, pvars := fftest.PairPflag()
+			pvars.ParseError = ff.Parse(ff.FromPflag(pfs), []string{},
+				ff.WithConfigFile(testcase.file),
+				ff.WithConfigFileParser(fftoml.Parser),
+			)
+			if err := fftest.Compare(&testcase.want, pvars); err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 }

--- a/ffyaml/ffyaml_test.go
+++ b/ffyaml/ffyaml_test.go
@@ -68,6 +68,16 @@ func TestParser(t *testing.T) {
 			if err := fftest.Compare(&testcase.want, vars); err != nil {
 				t.Fatal(err)
 			}
+
+			pfs, pvars := fftest.PairPflag()
+			pvars.ParseError = ff.Parse(ff.FromPflag(pfs), []string{},
+				ff.WithConfigFile(testcase.file),
+				ff.WithConfigFileParser(ffyaml.Parser),
+				ff.WithAllowMissingConfigFile(true),
+			)
+			if err := fftest.Compare(&testcase.want, pvars); err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.14
 
 require (
 	github.com/pelletier/go-toml v1.6.0
+	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.2.4
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=

--- a/json_test.go
+++ b/json_test.go
@@ -50,7 +50,16 @@ func TestJSONParser(t *testing.T) {
 				ff.WithConfigFileParser(ff.JSONParser),
 			)
 			if err := fftest.Compare(&testcase.want, vars); err != nil {
-				t.Fatal(err)
+				t.Fatal("flag.FlagSet", err)
+			}
+
+			pfs, vars := fftest.PairPflag()
+			vars.ParseError = ff.Parse(ff.FromPflag(pfs), testcase.args,
+				ff.WithConfigFile(testcase.file),
+				ff.WithConfigFileParser(ff.JSONParser),
+			)
+			if err := fftest.Compare(&testcase.want, vars); err != nil {
+				t.Fatal("pflag.FlagSet", err)
 			}
 		})
 	}

--- a/parse.go
+++ b/parse.go
@@ -9,10 +9,24 @@ import (
 	"strings"
 )
 
+// FlagSet interface defines required minimum set of functions required for
+// parsing parameters.
+//
+// The standard library flag.FlagSet implements this interface. FromPflag
+// function is also provided in this package which can be used to adapt
+// pflag.FlagSet to FlagSet.
+type FlagSet interface {
+	Parse(arguments []string) error
+	Visit(fn func(*flag.Flag))
+	VisitAll(fn func(*flag.Flag))
+	Set(name, value string) error
+	Lookup(name string) *flag.Flag
+}
+
 // Parse the flags in the flag set from the provided (presumably commandline)
 // args. Additional options may be provided to parse from a config file and/or
 // environment variables in that priority order.
-func Parse(fs *flag.FlagSet, args []string, options ...Option) error {
+func Parse(fs FlagSet, args []string, options ...Option) error {
 	var c Context
 	for _, option := range options {
 		option(&c)

--- a/parse_test.go
+++ b/parse_test.go
@@ -152,6 +152,12 @@ func TestParseBasics(t *testing.T) {
 			if err := fftest.Compare(&testcase.want, vars); err != nil {
 				t.Fatal(err)
 			}
+
+			pfs, pvars := fftest.PairPflag()
+			pvars.ParseError = ff.Parse(ff.FromPflag(pfs), testcase.args, testcase.opts...)
+			if err := fftest.Compare(&testcase.want, vars); err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 }
@@ -194,14 +200,25 @@ func TestParseIssue16(t *testing.T) {
 			filename, cleanup := fftest.TempFile(t, testcase.data)
 			defer cleanup()
 
+			want := fftest.Vars{S: testcase.want}
+
 			fs, vars := fftest.Pair()
 			vars.ParseError = ff.Parse(fs, []string{},
 				ff.WithConfigFile(filename),
 				ff.WithConfigFileParser(ff.PlainParser),
 			)
 
-			want := fftest.Vars{S: testcase.want}
 			if err := fftest.Compare(&want, vars); err != nil {
+				t.Fatal(err)
+			}
+
+			pfs, pvars := fftest.PairPflag()
+			pvars.ParseError = ff.Parse(ff.FromPflag(pfs), []string{},
+				ff.WithConfigFile(filename),
+				ff.WithConfigFileParser(ff.PlainParser),
+			)
+
+			if err := fftest.Compare(&want, pvars); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -244,11 +261,19 @@ func TestParseConfigFile(t *testing.T) {
 				options = append(options, ff.WithAllowMissingConfigFile(true))
 			}
 
+			want := fftest.Vars{WantParseErrorIs: testcase.parseError}
+
 			fs, vars := fftest.Pair()
 			vars.ParseError = ff.Parse(fs, []string{}, options...)
 
-			want := fftest.Vars{WantParseErrorIs: testcase.parseError}
 			if err := fftest.Compare(&want, vars); err != nil {
+				t.Fatal(err)
+			}
+
+			pfs, pvars := fftest.PairPflag()
+			pvars.ParseError = ff.Parse(ff.FromPflag(pfs), []string{}, options...)
+
+			if err := fftest.Compare(&want, pvars); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/pflag.go
+++ b/pflag.go
@@ -1,0 +1,53 @@
+package ff
+
+import (
+	"flag"
+
+	"github.com/spf13/pflag"
+)
+
+// FromPflag adapts pflag.FlagSet to FlagSet interface defined in this package.
+func FromPflag(fs *pflag.FlagSet) FlagSet {
+	return pFlagSet{base: fs}
+}
+
+type pFlagSet struct {
+	base *pflag.FlagSet
+}
+
+func (fs pFlagSet) Parse(arguments []string) error {
+	return fs.base.Parse(arguments)
+}
+
+func (fs pFlagSet) Visit(fn func(*flag.Flag)) {
+	fs.base.Visit(func(pFlag *pflag.Flag) {
+		fn(pflag2std(pFlag))
+	})
+}
+
+func (fs pFlagSet) VisitAll(fn func(*flag.Flag)) {
+	fs.base.VisitAll(func(pFlag *pflag.Flag) {
+		fn(pflag2std(pFlag))
+	})
+}
+
+func (fs pFlagSet) Set(name, value string) error {
+	return fs.base.Set(name, value)
+}
+
+func (fs pFlagSet) Lookup(name string) *flag.Flag {
+	return pflag2std(fs.base.Lookup(name))
+}
+
+func pflag2std(pFlag *pflag.Flag) *flag.Flag {
+	if pFlag == nil {
+		return nil
+	}
+
+	return &flag.Flag{
+		Name:     pFlag.Name,
+		Usage:    pFlag.Usage,
+		Value:    pFlag.Value,
+		DefValue: pFlag.DefValue,
+	}
+}


### PR DESCRIPTION
FlagSet methods have the same function signatures as flag.FlagSet, so
*flag.FlagSet can be used as FlagSet, for different flag libraries one
can implement this interface. As an example AdaptPflag function converts
*pflag.FlagSet to FlagSet.