### PR TITLE
parse: add env var name to usage text

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ import (
 func main() {
 	fs := flag.NewFlagSet("myservice", flag.ExitOnError)
 	var (
-		port  = fs.Int("port", 8080, "listen port for server (also via PORT)")
-		debug = fs.Bool("debug", false, "log debug information (also via DEBUG)")
+		port  = fs.Int("port", 8080, "listen port for server")
+		debug = fs.Bool("debug", false, "log debug information")
 	)
 	ff.Parse(fs, os.Args[1:], ff.WithEnvVarNoPrefix())
 
@@ -112,4 +112,13 @@ $ env PORT=9090 myservice
 port 9090, debug false
 $ env PORT=9090 DEBUG=1 myservice -port=1234
 port 1234, debug true
+```
+
+The environment variable names are included in the usage text as follows:
+```
+Usage of myservice:
+  -debug
+    	log debug information (also via env var DEBUG)
+  -port int
+    	listen port for server (also via env var PORT) (default 8080)
 ```

--- a/fftoml/fftoml.go
+++ b/fftoml/fftoml.go
@@ -1,4 +1,4 @@
-// Package fftoml provides a TOML config file paser.
+// Package fftoml provides a TOML config file parser.
 package fftoml
 
 import (

--- a/fftoml/fftoml.go
+++ b/fftoml/fftoml.go
@@ -133,7 +133,7 @@ type ParseError struct {
 	Inner error
 }
 
-// Error implenents the error interface.
+// Error implements the error interface.
 func (e ParseError) Error() string {
 	return fmt.Sprintf("error parsing TOML config: %v", e.Inner)
 }

--- a/ffyaml/ffyaml.go
+++ b/ffyaml/ffyaml.go
@@ -1,4 +1,4 @@
-// Package ffyaml provides a YAML config file paser.
+// Package ffyaml provides a YAML config file parser.
 package ffyaml
 
 import (

--- a/ffyaml/ffyaml.go
+++ b/ffyaml/ffyaml.go
@@ -78,7 +78,7 @@ type ParseError struct {
 	Inner error
 }
 
-// Error implenents the error interface.
+// Error implements the error interface.
 func (e ParseError) Error() string {
 	return fmt.Sprintf("error parsing YAML config: %v", e.Inner)
 }

--- a/parse.go
+++ b/parse.go
@@ -32,6 +32,12 @@ func Parse(fs *flag.FlagSet, args []string, options ...Option) error {
 	if parseEnv := c.envVarPrefix != "" || c.envVarNoPrefix; parseEnv {
 		var visitErr error
 		fs.VisitAll(func(f *flag.Flag) {
+			var key string
+			key = strings.ToUpper(f.Name)
+			key = envVarReplacer.Replace(key)
+			key = maybePrefix(key, c.envVarNoPrefix, c.envVarPrefix)
+			f.Usage = fmt.Sprintf("%s (also via env var %s)", f.Usage, key)
+
 			if visitErr != nil {
 				return
 			}
@@ -39,11 +45,6 @@ func Parse(fs *flag.FlagSet, args []string, options ...Option) error {
 			if provided[f.Name] {
 				return
 			}
-
-			var key string
-			key = strings.ToUpper(f.Name)
-			key = envVarReplacer.Replace(key)
-			key = maybePrefix(key, c.envVarNoPrefix, c.envVarPrefix)
 
 			value := os.Getenv(key)
 			if value == "" {


### PR DESCRIPTION
Thanks for this great library !

This PR automatically adds environment variable names to each flag's usage text.

For example, a definition such as:
```go
var (
    port  = fs.Int("port", 8080, "listen port for server")
    debug = fs.Bool("debug", false, "log debug information")
)
ff.Parse(fs, os.Args[1:], ff.WithEnvVarNoPrefix())
```
would result in the following usage text:
```
Usage of myservice:
  -debug
    	log debug information (also via env var DEBUG)
  -port int
    	listen port for server (also via env var PORT) (default 8080)
```

Also fixed some small typos.
