### PR TITLE
Add Note for flag defaults when env var matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ func main() {
 	fmt.Printf("port %d, debug %v\n", *port, *debug)
 }
 ```
+> Note: Flag defaults are not considered when a matching environment variable is found. In the first example below, the default for the `port` *flag* is set to 8080, however, upon parsing with `ff.Parse` the `port` **variable** is actually set to 9090 as there was a `PORT` environment variable found. The `debug` **variable** in this example uses the default and is set to false as there is no matching environment variable to override it.
 
 ```
 $ env PORT=9090 myservice

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ func main() {
 	fmt.Printf("port %d, debug %v\n", *port, *debug)
 }
 ```
-> Note: Flag defaults are not considered when a matching environment variable is found. In the first example below, the default for the `port` *flag* is set to 8080, however, upon parsing with `ff.Parse` the `port` **variable** is actually set to 9090 as there was a `PORT` environment variable found. The `debug` **variable** in this example uses the default and is set to false as there is no matching environment variable to override it.
+> Note: Flag defaults are considered last. If no command line flag argument is sent and no matching env variable is found, the default is used.
 
 ```
 $ env PORT=9090 myservice


### PR DESCRIPTION
Hi @peterbourgon - thanks so much for this library. I found it at just the right time to save me a bunch of work! One thing that I had to do some testing around to make sure I understood how it worked was how ff would handle flag defaults. I like the way it works currently, I just thought I could add a note in to help newcomers like myself understand how the logic around precedence works for flag defaults. Does this make sense? Thanks for considering! Dan