### PR TITLE
Fix example demonstrating usage of env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ func main() {
 		port  = fs.Int("port", 8080, "listen port for server (also via PORT)")
 		debug = fs.Bool("debug", false, "log debug information (also via DEBUG)")
 	)
-	if err := ff.Parse(fs, os.Args[1:], ff.WithEnvVars()); err != nil {
+	if err := ff.Parse(fs, os.Args[1:], ff.WithEnvVarNoPrefix()); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
It seems `WithEnvVars` does not exist in version 3, but instead `WithEnvVarNoPrefix` is now doing what is described in the example.