### PR TITLE
feat: ffyaml nested nodes

### DIFF
--- a/ffyaml/ffyaml_test.go
+++ b/ffyaml/ffyaml_test.go
@@ -132,7 +132,7 @@ func TestParser_WithNested(t *testing.T) {
 			stringsKey: "strings.nested.key",
 		},
 		{
-			name:       "defaults",
+			name:       "delimiter",
 			opts:       []ffyaml.Option{ffyaml.WithNodeDelimiter("-")},
 			stringKey:  "string-key",
 			boolKey:    "string-false",

--- a/ffyaml/testdata/nested.yaml
+++ b/ffyaml/testdata/nested.yaml
@@ -1,0 +1,12 @@
+string:
+  key: "a string"
+  false: true
+float:
+  nested:
+    key: 1.23
+strings:
+  nested:
+    key:
+      - "one"
+      - "two"
+      - "three"


### PR DESCRIPTION
Similar to the TOML parser, this allows for the YAML parser to interpret nested nodes.

e.g. 
```yaml
myapp:
  foo: bar
```

Using similar defaults from the TOML parser, the above would resolve from a flag like `-myapp.foo bar`

A large chunk of the TOML parser (and subsequent test) was copied and modified to work with the YAML library.