### PR TITLE
feat(ffyaml): add WithKeyPath parser option

### DIFF
--- a/ffyaml/testdata/key_path.yaml
+++ b/ffyaml/testdata/key_path.yaml
@@ -1,0 +1,5 @@
+root:
+  child1:
+    s: child1 value
+  child2:
+    s: child2 value

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/pelletier/go-toml v1.9.5
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,5 @@ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3v
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Specifying a key path points the parser to a specific section of the YAML file. For example, given the YAML config:

    config:
      dev:
        value: 10
      prod:
        value: 100

The following will use the "dev" portion of the configuration file:

    ff.Parse(fs, []string{},
        ff.WithConfigFile(file),
        ff.WithConfigFileParser(
            ffyaml.New(ffyaml.WithKeyPath("config", "dev")).Parse
        ),
    )

Use cases for the feature include:

- Placing different configurations in the same file
- Using the same file for multiple tools (besides this parser)
- Using the same file for different instances of this parser