### PR TITLE
JSON, TOML, YAML: support for nested config data

### DIFF
--- a/ffcli/examples/objectctl/pkg/objectapi/client.go
+++ b/ffcli/examples/objectctl/pkg/objectapi/client.go
@@ -102,17 +102,17 @@ func (s *mockServer) list(token string) ([]Object, error) {
 }
 
 var defaultObjects = map[string]Object{
-	"apple": Object{
+	"apple": {
 		Key:    "apple",
 		Value:  "The fruit of any of certain other species of tree of the same genus.",
 		Access: mustParseTime(time.RFC3339, "2019-03-15T15:01:00Z"),
 	},
-	"beach": Object{
+	"beach": {
 		Key:    "beach",
 		Value:  "The shore of a body of water, especially when sandy or pebbly.",
 		Access: mustParseTime(time.RFC3339, "2019-04-20T12:21:30Z"),
 	},
-	"carillon": Object{
+	"carillon": {
 		Key:    "carillon",
 		Value:  "A stationary set of chromatically tuned bells in a tower.",
 		Access: mustParseTime(time.RFC3339, "2019-07-04T23:59:59Z"),

--- a/fftest/tempfile.go
+++ b/fftest/tempfile.go
@@ -16,7 +16,7 @@ func TempFile(t *testing.T, content string) string {
 
 	filename := filepath.Join(t.TempDir(), strconv.Itoa(rand.Int()))
 
-	if err := os.WriteFile(filename, []byte(content), 0600); err != nil {
+	if err := os.WriteFile(filename, []byte(content), 0o0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/fftoml/fftoml.go
+++ b/fftoml/fftoml.go
@@ -2,144 +2,36 @@
 package fftoml
 
 import (
-	"fmt"
 	"io"
-	"strconv"
 
 	"github.com/pelletier/go-toml"
-	"github.com/peterbourgon/ff/v3"
+	"github.com/peterbourgon/ff/v3/internal"
 )
 
-// Parser is a parser for TOML file format. Flags and their values are read
-// from the key/value pairs defined in the config file.
+// Parser is a helper function that uses a default ParseConfig.
 func Parser(r io.Reader, set func(name, value string) error) error {
-	return New().Parse(r, set)
+	return (&ParseConfig{}).Parse(r, set)
 }
 
-// ConfigFileParser is a parser for the TOML file format. Flags and their values
-// are read from the key/value pairs defined in the config file.
-// Nested tables and keys are concatenated with a delimiter to derive the
-// relevant flag name.
-type ConfigFileParser struct {
-	delimiter string
+// ParseConfig collects parameters for the TOML config file parser.
+type ParseConfig struct {
+	// Delimiter is used when concatenating nested node keys into a flag name.
+	// The default delimiter is ".".
+	Delimiter string
 }
 
-// New constructs and configures a ConfigFileParser using the provided options.
-func New(opts ...Option) (c ConfigFileParser) {
-	c.delimiter = "."
-	for _, opt := range opts {
-		opt(&c)
-	}
-	return c
-}
-
-// Parse parses the provided io.Reader as a TOML file and uses the provided set function
-// to set flag names derived from the tables names and their key/value pairs.
-func (c ConfigFileParser) Parse(r io.Reader, set func(name, value string) error) error {
-	tree, err := toml.LoadReader(r)
-	if err != nil {
-		return ParseError{Inner: err}
+// Parse a TOML document from the provided io.Reader, using the provided set
+// function to set flag values. Flag names are derived from the node names and
+// their key/value pairs.
+func (pc *ParseConfig) Parse(r io.Reader, set func(name, value string) error) error {
+	if pc.Delimiter == "" {
+		pc.Delimiter = "."
 	}
 
-	return parseTree(tree, "", c.delimiter, set)
-}
-
-// Option is a function which changes the behavior of the TOML config file parser.
-type Option func(*ConfigFileParser)
-
-// WithTableDelimiter is an option which configures a delimiter
-// used to prefix table names onto keys when constructing
-// their associated flag name.
-// The default delimiter is "."
-//
-// For example, given the following TOML
-//
-//	[section.subsection]
-//	value = 10
-//
-// Parse will match to a flag with the name `-section.subsection.value` by default.
-// If the delimiter is "-", Parse will match to `-section-subsection-value` instead.
-func WithTableDelimiter(d string) Option {
-	return func(c *ConfigFileParser) {
-		c.delimiter = d
+	var m map[string]any
+	if err := toml.NewDecoder(r).Decode(&m); err != nil {
+		return err
 	}
-}
 
-func parseTree(tree *toml.Tree, parent, delimiter string, set func(name, value string) error) error {
-	for _, key := range tree.Keys() {
-		name := key
-		if parent != "" {
-			name = parent + delimiter + key
-		}
-		switch t := tree.Get(key).(type) {
-		case *toml.Tree:
-			if err := parseTree(t, name, delimiter, set); err != nil {
-				return err
-			}
-		case interface{}:
-			values, err := valsToStrs(t)
-			if err != nil {
-				return ParseError{Inner: err}
-			}
-			for _, value := range values {
-				if err = set(name, value); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
-}
-
-func valsToStrs(val interface{}) ([]string, error) {
-	if vals, ok := val.([]interface{}); ok {
-		ss := make([]string, len(vals))
-		for i := range vals {
-			s, err := valToStr(vals[i])
-			if err != nil {
-				return nil, err
-			}
-			ss[i] = s
-		}
-		return ss, nil
-	}
-	s, err := valToStr(val)
-	if err != nil {
-		return nil, err
-	}
-	return []string{s}, nil
-
-}
-
-func valToStr(val interface{}) (string, error) {
-	switch v := val.(type) {
-	case string:
-		return v, nil
-	case bool:
-		return strconv.FormatBool(v), nil
-	case uint64:
-		return strconv.FormatUint(v, 10), nil
-	case int64:
-		return strconv.FormatInt(v, 10), nil
-	case float64:
-		return strconv.FormatFloat(v, 'g', -1, 64), nil
-	default:
-		return "", ff.StringConversionError{Value: val}
-	}
-}
-
-// ParseError wraps all errors originating from the TOML parser.
-type ParseError struct {
-	Inner error
-}
-
-// Error implenents the error interface.
-func (e ParseError) Error() string {
-	return fmt.Sprintf("error parsing TOML config: %v", e.Inner)
-}
-
-// Unwrap implements the errors.Wrapper interface, allowing errors.Is and
-// errors.As to work with ParseErrors.
-func (e ParseError) Unwrap() error {
-	return e.Inner
+	return internal.TraverseMap(m, pc.Delimiter, set)
 }

--- a/fftoml/fftoml_test.go
+++ b/fftoml/fftoml_test.go
@@ -2,7 +2,9 @@ package fftoml_test
 
 import (
 	"flag"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,61 +58,50 @@ func TestParser(t *testing.T) {
 func TestParser_WithTables(t *testing.T) {
 	t.Parallel()
 
-	type fields struct {
-		String  string
-		Float   float64
-		Strings fftest.StringSlice
-	}
-
-	expected := fields{
-		String:  "a string",
-		Float:   1.23,
-		Strings: fftest.StringSlice{"one", "two", "three"},
-	}
-
-	for _, testcase := range []struct {
-		name string
-		opts []fftoml.Option
-		// expectations
-		stringKey  string
-		floatKey   string
-		stringsKey string
-	}{
-		{
-			name:       "defaults",
-			stringKey:  "string.key",
-			floatKey:   "float.nested.key",
-			stringsKey: "strings.nested.key",
-		},
-		{
-			name:       "defaults",
-			opts:       []fftoml.Option{fftoml.WithTableDelimiter("-")},
-			stringKey:  "string-key",
-			floatKey:   "float-nested-key",
-			stringsKey: "strings-nested-key",
-		},
+	for _, delim := range []string{
+		".",
+		"-",
 	} {
-		t.Run(testcase.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("delim=%q", delim), func(t *testing.T) {
 			var (
-				found fields
-				fs    = flag.NewFlagSet("fftest", flag.ContinueOnError)
+				skey = strings.Join([]string{"string", "key"}, delim)
+				fkey = strings.Join([]string{"float", "nested", "key"}, delim)
+				xkey = strings.Join([]string{"strings", "nested", "key"}, delim)
+
+				sval string
+				fval float64
+				xval fftest.StringSlice
 			)
 
-			fs.StringVar(&found.String, testcase.stringKey, "", "string")
-			fs.Float64Var(&found.Float, testcase.floatKey, 0, "float64")
-			fs.Var(&found.Strings, testcase.stringsKey, "string slice")
+			fs := flag.NewFlagSet("fftest", flag.ContinueOnError)
+			{
+				fs.StringVar(&sval, skey, "xxx", "string")
+				fs.Float64Var(&fval, fkey, 999, "float64")
+				fs.Var(&xval, xkey, "strings")
+			}
+
+			pc := fftoml.ParseConfig{
+				Delimiter: delim,
+			}
 
 			if err := ff.Parse(fs, []string{},
 				ff.WithConfigFile("testdata/table.toml"),
-				ff.WithConfigFileParser(fftoml.New(testcase.opts...).Parse),
+				ff.WithConfigFileParser(pc.Parse),
 			); err != nil {
 				t.Fatal(err)
 			}
 
-			if !reflect.DeepEqual(expected, found) {
-				t.Errorf(`expected %v, to be %v`, found, expected)
+			if want, have := "a string", sval; want != have {
+				t.Errorf("string key: want %q, have %q", want, have)
+			}
+
+			if want, have := 1.23, fval; want != have {
+				t.Errorf("float nested key: want %v, have %v", want, have)
+			}
+
+			if want, have := (fftest.StringSlice{"one", "two", "three"}), xval; !reflect.DeepEqual(want, have) {
+				t.Errorf("strings nested key: want %v, have %v", want, have)
 			}
 		})
 	}
-
 }

--- a/ffyaml/ffyaml.go
+++ b/ffyaml/ffyaml.go
@@ -2,91 +2,37 @@
 package ffyaml
 
 import (
-	"fmt"
+	"errors"
 	"io"
-	"strconv"
 
-	"github.com/peterbourgon/ff/v3"
+	"github.com/peterbourgon/ff/v3/internal"
 	"gopkg.in/yaml.v2"
 )
 
-// Parser is a parser for YAML file format. Flags and their values are read
-// from the key/value pairs defined in the config file.
+// Parser is a helper function that uses a default ParseConfig.
 func Parser(r io.Reader, set func(name, value string) error) error {
+	return (&ParseConfig{}).Parse(r, set)
+}
+
+// ParseConfig collects parameters for the YAML config file parser.
+type ParseConfig struct {
+	// Delimiter is used when concatenating nested node keys into a flag name.
+	// The default delimiter is ".".
+	Delimiter string
+}
+
+// Parse a YAML document from the provided io.Reader, using the provided set
+// function to set flag values. Flag names are derived from the node names and
+// their key/value pairs.
+func (pc *ParseConfig) Parse(r io.Reader, set func(name, value string) error) error {
+	if pc.Delimiter == "" {
+		pc.Delimiter = "."
+	}
+
 	var m map[string]interface{}
-	d := yaml.NewDecoder(r)
-	if err := d.Decode(&m); err != nil && err != io.EOF {
-		return ParseError{err}
+	if err := yaml.NewDecoder(r).Decode(&m); err != nil && !errors.Is(err, io.EOF) {
+		return err
 	}
-	for key, val := range m {
-		values, err := valsToStrs(val)
-		if err != nil {
-			return ParseError{err}
-		}
-		for _, value := range values {
-			if err := set(key, value); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
 
-func valsToStrs(val interface{}) ([]string, error) {
-	if vals, ok := val.([]interface{}); ok {
-		ss := make([]string, len(vals))
-		for i := range vals {
-			s, err := valToStr(vals[i])
-			if err != nil {
-				return nil, err
-			}
-			ss[i] = s
-		}
-		return ss, nil
-	}
-	s, err := valToStr(val)
-	if err != nil {
-		return nil, err
-	}
-	return []string{s}, nil
-
-}
-
-func valToStr(val interface{}) (string, error) {
-	switch v := val.(type) {
-	case byte:
-		return string([]byte{v}), nil
-	case string:
-		return v, nil
-	case bool:
-		return strconv.FormatBool(v), nil
-	case uint64:
-		return strconv.FormatUint(v, 10), nil
-	case int:
-		return strconv.Itoa(v), nil
-	case int64:
-		return strconv.FormatInt(v, 10), nil
-	case float64:
-		return strconv.FormatFloat(v, 'g', -1, 64), nil
-	case nil:
-		return "", nil
-	default:
-		return "", ff.StringConversionError{Value: val}
-	}
-}
-
-// ParseError wraps all errors originating from the YAML parser.
-type ParseError struct {
-	Inner error
-}
-
-// Error implenents the error interface.
-func (e ParseError) Error() string {
-	return fmt.Sprintf("error parsing YAML config: %v", e.Inner)
-}
-
-// Unwrap implements the errors.Wrapper interface, allowing errors.Is and
-// errors.As to work with ParseErrors.
-func (e ParseError) Unwrap() error {
-	return e.Inner
+	return internal.TraverseMap(m, pc.Delimiter, set)
 }

--- a/internal/doc.go
+++ b/internal/doc.go
@@ -1,0 +1,2 @@
+// Package internal provides private helpers used by various module packages.
+package internal

--- a/internal/traverse_map.go
+++ b/internal/traverse_map.go
@@ -1,0 +1,53 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// TraverseMap recursively walks the given map, calling set for each value. If the
+// value is a slice, set is called for each element of the slice. The keys of
+// nested maps are joined with the given delimiter.
+func TraverseMap(m map[string]any, delimiter string, set func(name, value string) error) error {
+	return traverseMap("", m, delimiter, set)
+}
+
+func traverseMap(key string, val any, delimiter string, set func(name, value string) error) error {
+	switch v := val.(type) {
+	case string:
+		return set(key, v)
+	case json.Number:
+		return set(key, v.String())
+	case uint64:
+		return set(key, strconv.FormatUint(v, 10))
+	case int:
+		return set(key, strconv.Itoa(v))
+	case int64:
+		return set(key, strconv.FormatInt(v, 10))
+	case float64:
+		return set(key, strconv.FormatFloat(v, 'g', -1, 64))
+	case bool:
+		return set(key, strconv.FormatBool(v))
+	case nil:
+		return set(key, "")
+	case []any:
+		for _, v := range v {
+			if err := traverseMap(key, v, delimiter, set); err != nil {
+				return err
+			}
+		}
+	case map[string]any:
+		for k, v := range v {
+			if key != "" {
+				k = key + delimiter + k
+			}
+			if err := traverseMap(k, v, delimiter, set); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("couldn't convert %q (type %T) to string", val, val)
+	}
+	return nil
+}

--- a/internal/traverse_map_test.go
+++ b/internal/traverse_map_test.go
@@ -1,0 +1,121 @@
+package internal_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/internal"
+)
+
+func TestTraverseMap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		Name  string
+		M     map[string]any
+		Delim string
+		Want  map[string]struct{}
+	}{
+		{
+			Name: "single values",
+			M: map[string]any{
+				"s":   "foo",
+				"i":   123,
+				"i64": int64(123),
+				"u":   uint64(123),
+				"f":   1.23,
+				"jn":  json.Number("123"),
+				"b":   true,
+				"nil": nil,
+			},
+			Delim: ".",
+			Want: map[string]struct{}{
+				"s=foo":   {},
+				"i=123":   {},
+				"i64=123": {},
+				"u=123":   {},
+				"f=1.23":  {},
+				"jn=123":  {},
+				"b=true":  {},
+				"nil=":    {},
+			},
+		},
+		{
+			Name: "slices",
+			M: map[string]any{
+				"is": []any{1, 2, 3},
+				"ss": []any{"a", "b", "c"},
+				"bs": []any{true, false},
+				"as": []any{"a", 1, true},
+			},
+			Want: map[string]struct{}{
+				"is=1":     {},
+				"is=2":     {},
+				"is=3":     {},
+				"ss=a":     {},
+				"ss=b":     {},
+				"ss=c":     {},
+				"bs=true":  {},
+				"bs=false": {},
+				"as=a":     {},
+				"as=1":     {},
+				"as=true":  {},
+			},
+		},
+		{
+			Name: "nested maps",
+			M: map[string]any{
+				"m": map[string]any{
+					"s": "foo",
+					"m2": map[string]any{
+						"i": 123,
+					},
+				},
+			},
+			Delim: ".",
+			Want: map[string]struct{}{
+				"m.s=foo":    {},
+				"m.m2.i=123": {},
+			},
+		},
+		{
+			Name: "nested maps with '-' delimiter",
+			M: map[string]any{
+				"m": map[string]any{
+					"s": "foo",
+					"m2": map[string]any{
+						"i": 123,
+					},
+				},
+			},
+			Delim: "-",
+			Want: map[string]struct{}{
+				"m-s=foo":    {},
+				"m-m2-i=123": {},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			observe := func(name, value string) error {
+				key := name + "=" + value
+				if _, ok := test.Want[key]; !ok {
+					t.Errorf("set(%s, %s): unexpected call to set", name, value)
+				}
+				delete(test.Want, key)
+				return nil
+			}
+
+			if err := internal.TraverseMap(test.M, test.Delim, observe); err != nil {
+				t.Fatal(err)
+			}
+
+			for key := range test.Want {
+				name, value, _ := strings.Cut(key, "=")
+				t.Errorf("set(%s, %s): expected but did not occur", name, value)
+			}
+		})
+	}
+}

--- a/json_parser.go
+++ b/json_parser.go
@@ -9,11 +9,11 @@ import (
 
 // JSONParser is a helper function that uses a default JSONParseConfig.
 func JSONParser(r io.Reader, set func(name, value string) error) error {
-	return (&ParseConfig{}).Parse(r, set)
+	return (&JSONParseConfig{}).Parse(r, set)
 }
 
 // JSONParseConfig collects parameters for the JSON config file parser.
-type ParseConfig struct {
+type JSONParseConfig struct {
 	// Delimiter is used when concatenating nested node keys into a flag name.
 	// The default delimiter is ".".
 	Delimiter string
@@ -22,7 +22,7 @@ type ParseConfig struct {
 // Parse a JSON document from the provided io.Reader, using the provided set
 // function to set flag values. Flag names are derived from the node names and
 // their key/value pairs.
-func (pc *ParseConfig) Parse(r io.Reader, set func(name, value string) error) error {
+func (pc *JSONParseConfig) Parse(r io.Reader, set func(name, value string) error) error {
 	if pc.Delimiter == "" {
 		pc.Delimiter = "."
 	}

--- a/json_parser.go
+++ b/json_parser.go
@@ -2,91 +2,38 @@ package ff
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
-	"strconv"
+
+	"github.com/peterbourgon/ff/v3/internal"
 )
 
-// JSONParser is a parser for config files in JSON format. Input should be
-// an object. The object's keys are treated as flag names, and the object's
-// values as flag values. If the value is an array, the flag will be set
-// multiple times.
+// JSONParser is a helper function that uses a default JSONParseConfig.
 func JSONParser(r io.Reader, set func(name, value string) error) error {
-	var m map[string]interface{}
+	return (&ParseConfig{}).Parse(r, set)
+}
+
+// JSONParseConfig collects parameters for the JSON config file parser.
+type ParseConfig struct {
+	// Delimiter is used when concatenating nested node keys into a flag name.
+	// The default delimiter is ".".
+	Delimiter string
+}
+
+// Parse a JSON document from the provided io.Reader, using the provided set
+// function to set flag values. Flag names are derived from the node names and
+// their key/value pairs.
+func (pc *ParseConfig) Parse(r io.Reader, set func(name, value string) error) error {
+	if pc.Delimiter == "" {
+		pc.Delimiter = "."
+	}
+
 	d := json.NewDecoder(r)
-	d.UseNumber() // must set UseNumber for stringifyValue to work
+	d.UseNumber() // required for stringifying values
+
+	var m map[string]interface{}
 	if err := d.Decode(&m); err != nil {
-		return JSONParseError{Inner: err}
+		return err
 	}
-	for key, val := range m {
-		values, err := stringifySlice(val)
-		if err != nil {
-			return JSONParseError{Inner: err}
-		}
-		for _, value := range values {
-			if err := set(key, value); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
 
-func stringifySlice(val interface{}) ([]string, error) {
-	if vals, ok := val.([]interface{}); ok {
-		ss := make([]string, len(vals))
-		for i := range vals {
-			s, err := stringifyValue(vals[i])
-			if err != nil {
-				return nil, err
-			}
-			ss[i] = s
-		}
-		return ss, nil
-	}
-	s, err := stringifyValue(val)
-	if err != nil {
-		return nil, err
-	}
-	return []string{s}, nil
-}
-
-func stringifyValue(val interface{}) (string, error) {
-	switch v := val.(type) {
-	case string:
-		return v, nil
-	case json.Number:
-		return v.String(), nil
-	case bool:
-		return strconv.FormatBool(v), nil
-	default:
-		return "", StringConversionError{Value: val}
-	}
-}
-
-// JSONParseError wraps all errors originating from the JSONParser.
-type JSONParseError struct {
-	Inner error
-}
-
-// Error implenents the error interface.
-func (e JSONParseError) Error() string {
-	return fmt.Sprintf("error parsing JSON config: %v", e.Inner)
-}
-
-// Unwrap implements the errors.Wrapper interface, allowing errors.Is and
-// errors.As to work with JSONParseErrors.
-func (e JSONParseError) Unwrap() error {
-	return e.Inner
-}
-
-// StringConversionError is returned when a value in a config file
-// can't be converted to a string, to be provided to a flag.
-type StringConversionError struct {
-	Value interface{}
-}
-
-// Error implements the error interface.
-func (e StringConversionError) Error() string {
-	return fmt.Sprintf("couldn't convert %q (type %T) to string", e.Value, e.Value)
+	return internal.TraverseMap(m, pc.Delimiter, set)
 }


### PR DESCRIPTION
This PR is a simple adaptation of the TraverseMap function from https://github.com/jolheiser/ff/pull/1 (thanks, @jolheiser!) which is applied to the JSON, TOML, and YAML config file parsers more or less in the same way. It allows nested config data in any of those formats to map to flag names in a reasonably well-defined way.

Addresses #107 and #108. I'm pretty sure this isn't a breaking change, but I'd appreciate a review from anyone who'd care to give it a look.

This is a precursor to a much larger refactor, including many highly requested features, coming soon to theaters near you.