### PR TITLE
fix: WithFilesystem option should take a io.FS as a parameter

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,7 +1,6 @@
 package ff
 
 import (
-	"embed"
 	"io"
 	iofs "io/fs"
 )
@@ -127,7 +126,7 @@ func WithEnvVarSplit(delimiter string) Option {
 // files on disk, typically when reading a config file.
 //
 // By default, the host filesystem is used, via [os.Open].
-func WithFilesystem(fs embed.FS) Option {
+func WithFilesystem(fs iofs.FS) Option {
 	return func(pc *ParseContext) {
 		pc.configOpenFunc = fs.Open
 	}


### PR DESCRIPTION
Taking the FS interface instead of the concrete implementation of embed.FS allows passing any kind of filesystem