### PR TITLE
added WithGetenvFunc option

### DIFF
--- a/options.go
+++ b/options.go
@@ -20,6 +20,8 @@ type ParseContext struct {
 	configOpenFunc             func(string) (iofs.File, error)
 	configAllowMissingFile     bool
 	configIgnoreUndefinedFlags bool
+
+	getenvFunc func(string) string // alternate implementation of os.Getenv
 }
 
 // ConfigFileParseFunc is a function that consumes the provided reader as a config
@@ -135,5 +137,17 @@ func WithEnvVarSplit(delimiter string) Option {
 func WithFilesystem(fs iofs.FS) Option {
 	return func(pc *ParseContext) {
 		pc.configOpenFunc = fs.Open
+	}
+}
+
+// WithGetenvFunc is like [WithEnvVars], but with a controlled environment lookup
+// The provided function will be used rather than os.Getenv when looking up env vars
+// This allows tests to be run using t.Parallel with a controlled environment state
+//
+// By default os.Getenv is used
+func WithGetenvFunc(f func(string) string) Option {
+	return func(pc *ParseContext) {
+		pc.envVarEnabled = true
+		pc.getenvFunc = f
 	}
 }

--- a/parse.go
+++ b/parse.go
@@ -91,7 +91,7 @@ func parse(fs Flags, args []string, options ...Option) error {
 					key := getEnvVarKey(name, pc.envVarPrefix)
 
 					// Look up the value from the environment.
-					val := os.Getenv(key)
+					val := getenv(pc.getenvFunc, key)
 					if val == "" {
 						continue
 					}
@@ -200,6 +200,15 @@ func parse(fs Flags, args []string, options ...Option) error {
 	}
 
 	return nil
+}
+
+// getenv returns the value of the environment variable with the given key.
+// If fn is nil, os.Getenv is used.  This is mostly used to inject non-global state from tests.
+func getenv(fn func(string) string, key string) string {
+	if fn != nil {
+		return fn(key)
+	}
+	return os.Getenv(key)
 }
 
 //


### PR DESCRIPTION
added WithGetenvFunc option so that from tests we do not have to rely on global state, defaults to os.Getenv still