### PR TITLE
Fix ErrDuplicateFlags when no env var parsing is requested

### DIFF
--- a/fftest/test_case.go
+++ b/fftest/test_case.go
@@ -59,6 +59,7 @@ func (tc *ParseTest) Run(t *testing.T) {
 			parseFunc = fftoml.Parse
 		case ".env":
 			parseFunc = ffenv.Parse
+			opts = append(opts, ff.WithEnvVars())
 		default:
 			parseFunc = ff.PlainParser
 		}

--- a/flag_set_test.go
+++ b/flag_set_test.go
@@ -295,6 +295,19 @@ func TestFlagSet_invalid(t *testing.T) {
 		_ = fs.Bool('a', "apple", "this should panic")
 	})
 
+	t.Run("same fold short name", func(t *testing.T) {
+		defer func() {
+			if x := recover(); x == nil {
+				t.Logf("have not expected panic (%v)", x)
+			} else {
+				t.Errorf("want peace, have panic")
+			}
+		}()
+		fs := ff.NewFlagSet(t.Name())
+		_ = fs.Bool('a', "alpha", "this should be OK")
+		_ = fs.Bool('A', "apple", "this should be OK")
+	})
+
 	t.Run("duplicate long name", func(t *testing.T) {
 		defer func() {
 			if x := recover(); x == nil {

--- a/parse_test.go
+++ b/parse_test.go
@@ -449,10 +449,10 @@ func TestParse_shortSameCase(t *testing.T) {
 	})
 	t.Run("WithEnv", func(t *testing.T) {
 		t.Parallel()
-		if err := ff.Parse(newFS(), args, ff.WithEnvVars()); err == nil {
-			t.Error("wanted ErrDuplicateFlage, got nil")
-		} else if !errors.Is(err, ff.ErrDuplicateFlag) {
-			t.Errorf("wanted ErrDuplicateFlage, got %+v", err)
+		if err := ff.Parse(
+			newFS(), args, ff.WithEnvVars(),
+		); err == nil || !errors.Is(err, ff.ErrDuplicateFlag) {
+			t.Errorf("wanted ErrDuplicateFlag, got %+v", err)
 		}
 	})
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -451,7 +451,7 @@ func TestParse_shortSameCase(t *testing.T) {
 		t.Parallel()
 		if err := ff.Parse(
 			newFS(), args, ff.WithEnvVars(),
-		); err == nil || !errors.Is(err, ff.ErrDuplicateFlag) {
+		); !errors.Is(err, ff.ErrDuplicateFlag) {
 			t.Errorf("wanted ErrDuplicateFlag, got %+v", err)
 		}
 	})


### PR DESCRIPTION
Same cased short flags should be possible, but ErrDuplicateFlags is returned even when environment variable parsing is not requested.
Do not check for duplicate folds if no env var is requested.