### PR TITLE
Improved support for Func flags

### DIFF
--- a/ffval/value.go
+++ b/ffval/value.go
@@ -235,3 +235,21 @@ func (v *reflectValue) Set(s string) error     { return v.set(s) }
 func (v *reflectValue) String() string         { return v.get() }
 func (v *reflectValue) IsBoolFlag() bool       { return v.isBoolFlag }
 func (v *reflectValue) GetPlaceholder() string { return v.placeholder }
+
+//
+//
+//
+
+// Func implements [flag.Value] for a function that takes a string and returns
+// an error. It has essentially the same behavior as a stdlib [flag.Func].
+type Func func(string) error
+
+var _ flag.Value = (*Func)(nil)
+
+func (fn Func) Set(s string) error {
+	return fn(s)
+}
+
+func (fn Func) String() string {
+	return ""
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/peterbourgon/ff/v4
 
-go 1.20
+go 1.21.0
 
 require (
 	github.com/pelletier/go-toml/v2 v2.0.9


### PR DESCRIPTION
This PR improves support for Func flags. The main change is the addition of ff.FlagSet.FuncConfigVar, which was essentially missing until now. We also introduce ffval.Func and use it instead of the previous approach, which was basically piggybacking on the stdlib flag.Func value. This PR also improves the documentation for the FlagSet type.

Closes #150.